### PR TITLE
feat(tests): add full pytest test suite with factory-boy

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,32 @@
+name: Tests
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+
+      - name: Run tests
+        run: pytest comuni_italiani/tests/

--- a/comuni_italiani/tests/comuni/test_comuni_api.py
+++ b/comuni_italiani/tests/comuni/test_comuni_api.py
@@ -1,0 +1,66 @@
+import pytest
+from django.urls import reverse
+
+from comuni_italiani.tests.factories import ComuneFactory
+
+
+@pytest.mark.django_db
+class TestComuniListAPI:
+    def test_list_returns_200(self, api_client):
+        response = api_client.get(reverse("comuni-list"))
+        assert response.status_code == 200
+
+    def test_list_contains_created_comune(self, api_client, comune):
+        response = api_client.get(reverse("comuni-list"))
+        ids = [c["id"] for c in response.data["results"]]
+        assert comune.pk in ids
+
+    def test_list_is_paginated(self, api_client, db):
+        ComuneFactory.create_batch(5)
+        response = api_client.get(reverse("comuni-list"))
+        assert "results" in response.data
+        assert "count" in response.data
+
+    def test_post_not_allowed(self, api_client):
+        response = api_client.post(reverse("comuni-list"), data={})
+        assert response.status_code == 405
+
+    def test_search_by_denomination(self, api_client, db):
+        ComuneFactory(denomination="Torino")
+        ComuneFactory(denomination="Milano")
+        response = api_client.get(reverse("comuni-list"), {"search": "Tori"})
+        assert response.data["count"] == 1
+        assert response.data["results"][0]["denomination"] == "Torino"
+
+    def test_search_orders_by_denomination_length(self, api_client, db):
+        ComuneFactory(denomination="Roma")
+        ComuneFactory(denomination="Alessandria")
+        response = api_client.get(reverse("comuni-list"), {"search": "a"})
+        denominations = [c["denomination"] for c in response.data["results"]]
+        lengths = [len(d) for d in denominations]
+        assert lengths == sorted(lengths)
+
+
+@pytest.mark.django_db
+class TestComuniDetailAPI:
+    def test_retrieve_returns_200(self, api_client, comune):
+        response = api_client.get(reverse("comuni-detail", args=[comune.pk]))
+        assert response.status_code == 200
+
+    def test_retrieve_correct_data(self, api_client, comune):
+        response = api_client.get(reverse("comuni-detail", args=[comune.pk]))
+        assert response.data["id"] == comune.pk
+        assert response.data["code"] == comune.code
+        assert response.data["denomination"] == comune.denomination
+
+    def test_retrieve_unknown_returns_404(self, api_client):
+        response = api_client.get(reverse("comuni-detail", args=[9999]))
+        assert response.status_code == 404
+
+    def test_put_not_allowed(self, api_client, comune):
+        response = api_client.put(reverse("comuni-detail", args=[comune.pk]), data={})
+        assert response.status_code == 405
+
+    def test_delete_not_allowed(self, api_client, comune):
+        response = api_client.delete(reverse("comuni-detail", args=[comune.pk]))
+        assert response.status_code == 405

--- a/comuni_italiani/tests/comuni/test_comuni_filters.py
+++ b/comuni_italiani/tests/comuni/test_comuni_filters.py
@@ -1,0 +1,72 @@
+import pytest
+from django.urls import reverse
+
+from comuni_italiani.tests.factories import ComuneFactory, ProvinciaFactory
+
+
+@pytest.mark.django_db
+class TestComuneFilters:
+    def test_filter_by_code_icontains(self, api_client, db):
+        ComuneFactory(code="000001")
+        ComuneFactory(code="000002")
+        response = api_client.get(reverse("comuni-list"), {"code": "000001"})
+        assert response.data["count"] == 1
+
+    def test_filter_by_denomination_icontains(self, api_client, db):
+        ComuneFactory(denomination="Torino")
+        ComuneFactory(denomination="Milano")
+        response = api_client.get(reverse("comuni-list"), {"denomination": "Tori"})
+        assert response.data["count"] == 1
+        assert response.data["results"][0]["denomination"] == "Torino"
+
+    def test_filter_by_denomination_case_insensitive(self, api_client, db):
+        ComuneFactory(denomination="Torino")
+        response = api_client.get(reverse("comuni-list"), {"denomination": "TORI"})
+        assert response.data["count"] == 1
+
+    def test_filter_by_geographic_partition(self, api_client, db):
+        ComuneFactory(geographic_partition="Nord-Ovest")
+        ComuneFactory(geographic_partition="Sud")
+        response = api_client.get(reverse("comuni-list"), {"geographic_partition": "Nord"})
+        assert response.data["count"] == 1
+
+    def test_filter_by_progressive(self, api_client, db):
+        ComuneFactory(progressive=10)
+        ComuneFactory(progressive=20)
+        response = api_client.get(reverse("comuni-list"), {"progressive": 10})
+        assert response.data["count"] == 1
+        assert response.data["results"][0]["progressive"] == 10
+
+    def test_filter_by_province_id_single(self, api_client, db):
+        provincia = ProvinciaFactory()
+        target = ComuneFactory(province=provincia)
+        ComuneFactory()
+        response = api_client.get(reverse("comuni-list"), {"province_id": provincia.pk})
+        assert response.data["count"] == 1
+        assert response.data["results"][0]["id"] == target.pk
+
+    def test_filter_by_province_id_multiple(self, api_client, db):
+        p1 = ProvinciaFactory()
+        p2 = ProvinciaFactory()
+        ComuneFactory(province=p1)
+        ComuneFactory(province=p2)
+        ComuneFactory()
+        response = api_client.get(
+            reverse("comuni-list"), {"province_id": f"{p1.pk},{p2.pk}"}
+        )
+        assert response.data["count"] == 2
+
+    def test_filter_by_province_denomination(self, api_client, db):
+        p1 = ProvinciaFactory(denomination="Torino")
+        p2 = ProvinciaFactory(denomination="Milano")
+        ComuneFactory(province=p1)
+        ComuneFactory(province=p2)
+        response = api_client.get(
+            reverse("comuni-list"), {"province_denomination": "Torino"}
+        )
+        assert response.data["count"] == 1
+
+    def test_filter_no_match_returns_empty(self, api_client, db):
+        ComuneFactory(denomination="Torino")
+        response = api_client.get(reverse("comuni-list"), {"denomination": "Palermo"})
+        assert response.data["count"] == 0

--- a/comuni_italiani/tests/comuni/test_comuni_models.py
+++ b/comuni_italiani/tests/comuni/test_comuni_models.py
@@ -1,0 +1,36 @@
+import pytest
+from django.db import IntegrityError
+
+from comuni_italiani.tests.factories import ComuneFactory, ProvinciaFactory
+
+
+@pytest.mark.django_db
+class TestComuneModel:
+    def test_str(self, comune):
+        assert str(comune) == f"Comune: {comune.denomination}"
+
+    def test_code_is_unique(self, db):
+        ComuneFactory(code="000001")
+        with pytest.raises(IntegrityError):
+            ComuneFactory(code="000001")
+
+    def test_cascade_delete_from_provincia(self, db):
+        from comuni_italiani.models import Comune
+
+        provincia = ProvinciaFactory()
+        ComuneFactory(province=provincia)
+        provincia.delete()
+        assert Comune.objects.count() == 0
+
+    def test_ordering_by_denomination(self, db):
+        ComuneFactory(denomination="Torino")
+        ComuneFactory(denomination="Aosta")
+        ComuneFactory(denomination="Milano")
+        from comuni_italiani.models import Comune
+
+        denominations = list(Comune.objects.values_list("denomination", flat=True))
+        assert denominations == sorted(denominations)
+
+    def test_geographic_partition_can_be_null(self, db):
+        comune = ComuneFactory(geographic_partition=None)
+        assert comune.geographic_partition is None

--- a/comuni_italiani/tests/comuni/test_comuni_serializers.py
+++ b/comuni_italiani/tests/comuni/test_comuni_serializers.py
@@ -1,0 +1,37 @@
+import pytest
+
+from comuni_italiani.serializers import ComuneSerializer
+from comuni_italiani.tests.factories import ComuneFactory
+
+
+@pytest.mark.django_db
+class TestComuneSerializer:
+    def test_contains_expected_fields(self, comune):
+        data = ComuneSerializer(comune).data
+        assert set(data.keys()) == {
+            "id",
+            "province",
+            "code",
+            "progressive",
+            "denomination",
+            "geographic_partition",
+        }
+
+    def test_province_nested_fields(self, comune):
+        data = ComuneSerializer(comune).data
+        assert set(data["province"].keys()) == {
+            "id",
+            "code",
+            "denomination",
+            "geographic_partition",
+            "auto_code",
+        }
+
+    def test_dynamic_fields(self, comune):
+        data = ComuneSerializer(comune, fields=["id", "denomination"]).data
+        assert set(data.keys()) == {"id", "denomination"}
+
+    def test_progressive_value(self, db):
+        comune = ComuneFactory(progressive=42)
+        data = ComuneSerializer(comune).data
+        assert data["progressive"] == 42

--- a/comuni_italiani/tests/conftest.py
+++ b/comuni_italiani/tests/conftest.py
@@ -1,0 +1,28 @@
+import pytest
+from rest_framework.test import APIClient
+
+from comuni_italiani.tests.factories import (
+    ComuneFactory,
+    ProvinciaFactory,
+    RegioneFactory,
+)
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.fixture
+def regione(db):
+    return RegioneFactory()
+
+
+@pytest.fixture
+def provincia(db):
+    return ProvinciaFactory()
+
+
+@pytest.fixture
+def comune(db):
+    return ComuneFactory()

--- a/comuni_italiani/tests/factories.py
+++ b/comuni_italiani/tests/factories.py
@@ -1,0 +1,44 @@
+import string
+
+import factory
+from factory.django import DjangoModelFactory
+
+from comuni_italiani.models import Comune, Provincia, Regione
+
+_GEO_PARTITIONS = ["Nord-Ovest", "Nord-Est", "Centro", "Sud", "Isole"]
+
+
+class RegioneFactory(DjangoModelFactory):
+    class Meta:
+        model = Regione
+
+    code = factory.Sequence(lambda n: f"{n + 1:02d}")
+    denomination = factory.Sequence(lambda n: f"Regione {n + 1}")
+    geographic_partition = factory.Iterator(_GEO_PARTITIONS)
+    data = factory.LazyAttribute(lambda o: {})
+
+
+class ProvinciaFactory(DjangoModelFactory):
+    class Meta:
+        model = Provincia
+
+    region = factory.SubFactory(RegioneFactory)
+    code = factory.Sequence(lambda n: f"{n + 1:03d}")
+    denomination = factory.Sequence(lambda n: f"Provincia {n + 1}")
+    geographic_partition = factory.Iterator(_GEO_PARTITIONS)
+    auto_code = factory.Sequence(
+        lambda n: string.ascii_uppercase[n % 26] + string.ascii_uppercase[(n // 26) % 26]
+    )
+    data = factory.LazyAttribute(lambda o: {})
+
+
+class ComuneFactory(DjangoModelFactory):
+    class Meta:
+        model = Comune
+
+    province = factory.SubFactory(ProvinciaFactory)
+    code = factory.Sequence(lambda n: f"{n + 1:06d}")
+    progressive = factory.Sequence(lambda n: n + 1)
+    denomination = factory.Sequence(lambda n: f"Comune {n + 1}")
+    geographic_partition = factory.Iterator(_GEO_PARTITIONS)
+    data = factory.LazyAttribute(lambda o: {})

--- a/comuni_italiani/tests/province/test_province_api.py
+++ b/comuni_italiani/tests/province/test_province_api.py
@@ -1,0 +1,74 @@
+import pytest
+from django.urls import reverse
+
+from comuni_italiani.tests.factories import (
+    ComuneFactory,
+    ProvinciaFactory,
+)
+
+
+@pytest.mark.django_db
+class TestProvinciaListAPI:
+    def test_list_returns_200(self, api_client):
+        response = api_client.get(reverse("province-list"))
+        assert response.status_code == 200
+
+    def test_list_contains_created_provincia(self, api_client, provincia):
+        response = api_client.get(reverse("province-list"))
+        ids = [p["id"] for p in response.data["results"]]
+        assert provincia.pk in ids
+
+    def test_list_uses_list_serializer(self, api_client, provincia):
+        response = api_client.get(reverse("province-list"))
+        result = response.data["results"][0]
+        assert "cities" not in result
+
+    def test_post_not_allowed(self, api_client):
+        response = api_client.post(reverse("province-list"), data={})
+        assert response.status_code == 405
+
+    def test_search_by_denomination(self, api_client, db):
+        ProvinciaFactory(denomination="Torino")
+        ProvinciaFactory(denomination="Milano")
+        response = api_client.get(reverse("province-list"), {"search": "Tori"})
+        assert response.data["count"] == 1
+        assert response.data["results"][0]["denomination"] == "Torino"
+
+    def test_search_orders_by_denomination_length(self, api_client, db):
+        ProvinciaFactory(denomination="Roma")
+        ProvinciaFactory(denomination="Alessandria")
+        response = api_client.get(reverse("province-list"), {"search": "a"})
+        denominations = [p["denomination"] for p in response.data["results"]]
+        lengths = [len(d) for d in denominations]
+        assert lengths == sorted(lengths)
+
+
+@pytest.mark.django_db
+class TestProvinciaDetailAPI:
+    def test_retrieve_returns_200(self, api_client, provincia):
+        response = api_client.get(reverse("province-detail", args=[provincia.pk]))
+        assert response.status_code == 200
+
+    def test_retrieve_uses_retrieve_serializer(self, api_client, db):
+        provincia = ProvinciaFactory()
+        ComuneFactory.create_batch(2, province=provincia)
+        response = api_client.get(reverse("province-detail", args=[provincia.pk]))
+        assert "cities" in response.data
+        assert len(response.data["cities"]) == 2
+
+    def test_retrieve_correct_data(self, api_client, provincia):
+        response = api_client.get(reverse("province-detail", args=[provincia.pk]))
+        assert response.data["id"] == provincia.pk
+        assert response.data["code"] == provincia.code
+
+    def test_retrieve_unknown_returns_404(self, api_client):
+        response = api_client.get(reverse("province-detail", args=[9999]))
+        assert response.status_code == 404
+
+    def test_put_not_allowed(self, api_client, provincia):
+        response = api_client.put(reverse("province-detail", args=[provincia.pk]), data={})
+        assert response.status_code == 405
+
+    def test_delete_not_allowed(self, api_client, provincia):
+        response = api_client.delete(reverse("province-detail", args=[provincia.pk]))
+        assert response.status_code == 405

--- a/comuni_italiani/tests/province/test_province_filters.py
+++ b/comuni_italiani/tests/province/test_province_filters.py
@@ -1,0 +1,55 @@
+import pytest
+from django.urls import reverse
+
+from comuni_italiani.tests.factories import ProvinciaFactory, RegioneFactory
+
+
+@pytest.mark.django_db
+class TestProvinciaFilters:
+    def test_filter_by_code_icontains(self, api_client, db):
+        ProvinciaFactory(code="001")
+        ProvinciaFactory(code="002")
+        response = api_client.get(reverse("province-list"), {"code": "001"})
+        assert response.data["count"] == 1
+
+    def test_filter_by_denomination_icontains(self, api_client, db):
+        ProvinciaFactory(denomination="Torino")
+        ProvinciaFactory(denomination="Milano")
+        response = api_client.get(reverse("province-list"), {"denomination": "Tori"})
+        assert response.data["count"] == 1
+        assert response.data["results"][0]["denomination"] == "Torino"
+
+    def test_filter_by_denomination_case_insensitive(self, api_client, db):
+        ProvinciaFactory(denomination="Torino")
+        response = api_client.get(reverse("province-list"), {"denomination": "TORI"})
+        assert response.data["count"] == 1
+
+    def test_filter_by_geographic_partition(self, api_client, db):
+        ProvinciaFactory(geographic_partition="Nord-Ovest")
+        ProvinciaFactory(geographic_partition="Sud")
+        response = api_client.get(reverse("province-list"), {"geographic_partition": "Nord"})
+        assert response.data["count"] == 1
+
+    def test_filter_by_region_id_single(self, api_client, db):
+        regione = RegioneFactory()
+        target = ProvinciaFactory(region=regione)
+        ProvinciaFactory()
+        response = api_client.get(reverse("province-list"), {"region_id": regione.pk})
+        assert response.data["count"] == 1
+        assert response.data["results"][0]["id"] == target.pk
+
+    def test_filter_by_region_id_multiple(self, api_client, db):
+        r1 = RegioneFactory()
+        r2 = RegioneFactory()
+        ProvinciaFactory(region=r1)
+        ProvinciaFactory(region=r2)
+        ProvinciaFactory()
+        response = api_client.get(
+            reverse("province-list"), {"region_id": f"{r1.pk},{r2.pk}"}
+        )
+        assert response.data["count"] == 2
+
+    def test_filter_no_match_returns_empty(self, api_client, db):
+        ProvinciaFactory(denomination="Torino")
+        response = api_client.get(reverse("province-list"), {"denomination": "Napoli"})
+        assert response.data["count"] == 0

--- a/comuni_italiani/tests/province/test_province_models.py
+++ b/comuni_italiani/tests/province/test_province_models.py
@@ -1,0 +1,36 @@
+import pytest
+from django.db import IntegrityError
+
+from comuni_italiani.tests.factories import ProvinciaFactory, RegioneFactory
+
+
+@pytest.mark.django_db
+class TestProvinciaModel:
+    def test_str(self, provincia):
+        assert str(provincia) == f"Provincia: {provincia.denomination}"
+
+    def test_code_is_unique(self, db):
+        ProvinciaFactory(code="001")
+        with pytest.raises(IntegrityError):
+            ProvinciaFactory(code="001")
+
+    def test_cascade_delete_from_region(self, db):
+        from comuni_italiani.models import Provincia
+
+        regione = RegioneFactory()
+        ProvinciaFactory(region=regione)
+        regione.delete()
+        assert Provincia.objects.count() == 0
+
+    def test_ordering_by_denomination(self, db):
+        ProvinciaFactory(denomination="Torino")
+        ProvinciaFactory(denomination="Alessandria")
+        ProvinciaFactory(denomination="Milano")
+        from comuni_italiani.models import Provincia
+
+        denominations = list(Provincia.objects.values_list("denomination", flat=True))
+        assert denominations == sorted(denominations)
+
+    def test_auto_code_can_be_null(self, db):
+        provincia = ProvinciaFactory(auto_code=None)
+        assert provincia.auto_code is None

--- a/comuni_italiani/tests/province/test_province_serializers.py
+++ b/comuni_italiani/tests/province/test_province_serializers.py
@@ -1,0 +1,67 @@
+import pytest
+
+from comuni_italiani.serializers import ProvinciaRetrieveSerializer, ProvinciaSerializer
+from comuni_italiani.tests.factories import ComuneFactory, ProvinciaFactory
+
+
+@pytest.mark.django_db
+class TestProvinciaSerializer:
+    def test_list_serializer_fields(self, provincia):
+        data = ProvinciaSerializer(provincia).data
+        assert set(data.keys()) == {
+            "id",
+            "region",
+            "code",
+            "denomination",
+            "geographic_partition",
+            "auto_code",
+        }
+
+    def test_region_nested_fields(self, provincia):
+        data = ProvinciaSerializer(provincia).data
+        assert set(data["region"].keys()) == {
+            "id",
+            "code",
+            "denomination",
+            "geographic_partition",
+        }
+
+    def test_dynamic_fields(self, provincia):
+        data = ProvinciaSerializer(provincia, fields=["id", "code"]).data
+        assert set(data.keys()) == {"id", "code"}
+
+
+@pytest.mark.django_db
+class TestProvinciaRetrieveSerializer:
+    def test_retrieve_serializer_includes_cities(self, db):
+        provincia = ProvinciaFactory()
+        ComuneFactory.create_batch(3, province=provincia)
+        data = ProvinciaRetrieveSerializer(provincia).data
+        assert "cities" in data
+        assert len(data["cities"]) == 3
+
+    def test_cities_nested_fields(self, db):
+        provincia = ProvinciaFactory()
+        ComuneFactory(province=provincia)
+        data = ProvinciaRetrieveSerializer(provincia).data
+        city = data["cities"][0]
+        assert set(city.keys()) == {
+            "id",
+            "code",
+            "progressive",
+            "denomination",
+            "geographic_partition",
+        }
+
+    def test_retrieve_serializer_all_fields(self, db):
+        provincia = ProvinciaFactory()
+        data = ProvinciaRetrieveSerializer(provincia).data
+        assert set(data.keys()) == {
+            "id",
+            "region",
+            "code",
+            "denomination",
+            "geographic_partition",
+            "auto_code",
+            "cities",
+        }

--- a/comuni_italiani/tests/regioni/fixtures.py
+++ b/comuni_italiani/tests/regioni/fixtures.py
@@ -1,13 +1,8 @@
 import pytest
 
-from comuni_italiani.models import Regione
+from comuni_italiani.tests.factories import RegioneFactory
 
 
 @pytest.fixture
-@pytest.mark.django_db
-def regione():
-    yield Regione.objects.create(
-        code="01",
-        denomination="Piemonte",
-        geographic_partition="Nord-Ovest",
-    )
+def regione(db):
+    yield RegioneFactory()

--- a/comuni_italiani/tests/regioni/test_regioni_api.py
+++ b/comuni_italiani/tests/regioni/test_regioni_api.py
@@ -1,0 +1,66 @@
+import pytest
+from django.urls import reverse
+
+from comuni_italiani.tests.factories import RegioneFactory
+
+
+@pytest.mark.django_db
+class TestRegioniListAPI:
+    def test_list_returns_200(self, api_client):
+        response = api_client.get(reverse("regioni-list"))
+        assert response.status_code == 200
+
+    def test_list_contains_created_regione(self, api_client, regione):
+        response = api_client.get(reverse("regioni-list"))
+        ids = [r["id"] for r in response.data["results"]]
+        assert regione.pk in ids
+
+    def test_list_is_paginated(self, api_client, db):
+        RegioneFactory.create_batch(5)
+        response = api_client.get(reverse("regioni-list"))
+        assert "results" in response.data
+        assert "count" in response.data
+
+    def test_post_not_allowed(self, api_client):
+        response = api_client.post(reverse("regioni-list"), data={})
+        assert response.status_code == 405
+
+    def test_search_by_denomination(self, api_client, db):
+        RegioneFactory(denomination="Piemonte")
+        RegioneFactory(denomination="Lombardia")
+        response = api_client.get(reverse("regioni-list"), {"search": "Piem"})
+        assert response.data["count"] == 1
+        assert response.data["results"][0]["denomination"] == "Piemonte"
+
+    def test_search_orders_by_denomination_length(self, api_client, db):
+        RegioneFactory(denomination="Lombardia")
+        RegioneFactory(denomination="Lazio")
+        response = api_client.get(reverse("regioni-list"), {"search": "La"})
+        denominations = [r["denomination"] for r in response.data["results"]]
+        lengths = [len(d) for d in denominations]
+        assert lengths == sorted(lengths)
+
+
+@pytest.mark.django_db
+class TestRegioniDetailAPI:
+    def test_retrieve_returns_200(self, api_client, regione):
+        response = api_client.get(reverse("regioni-detail", args=[regione.pk]))
+        assert response.status_code == 200
+
+    def test_retrieve_returns_correct_data(self, api_client, regione):
+        response = api_client.get(reverse("regioni-detail", args=[regione.pk]))
+        assert response.data["id"] == regione.pk
+        assert response.data["code"] == regione.code
+        assert response.data["denomination"] == regione.denomination
+
+    def test_retrieve_unknown_returns_404(self, api_client):
+        response = api_client.get(reverse("regioni-detail", args=[9999]))
+        assert response.status_code == 404
+
+    def test_put_not_allowed(self, api_client, regione):
+        response = api_client.put(reverse("regioni-detail", args=[regione.pk]), data={})
+        assert response.status_code == 405
+
+    def test_delete_not_allowed(self, api_client, regione):
+        response = api_client.delete(reverse("regioni-detail", args=[regione.pk]))
+        assert response.status_code == 405

--- a/comuni_italiani/tests/regioni/test_regioni_filters.py
+++ b/comuni_italiani/tests/regioni/test_regioni_filters.py
@@ -1,0 +1,44 @@
+import pytest
+from django.urls import reverse
+
+from comuni_italiani.tests.factories import RegioneFactory
+
+
+@pytest.mark.django_db
+class TestRegioneFilters:
+    def test_filter_by_code_exact(self, api_client, db):
+        RegioneFactory(code="01")
+        RegioneFactory(code="02")
+        response = api_client.get(reverse("regioni-list"), {"code": "01"})
+        assert response.data["count"] == 1
+        assert response.data["results"][0]["code"] == "01"
+
+    def test_filter_by_code_icontains(self, api_client, db):
+        RegioneFactory(code="01")
+        RegioneFactory(code="02")
+        response = api_client.get(reverse("regioni-list"), {"code": "0"})
+        assert response.data["count"] == 2
+
+    def test_filter_by_denomination_icontains(self, api_client, db):
+        RegioneFactory(denomination="Piemonte")
+        RegioneFactory(denomination="Lombardia")
+        response = api_client.get(reverse("regioni-list"), {"denomination": "piem"})
+        assert response.data["count"] == 1
+        assert response.data["results"][0]["denomination"] == "Piemonte"
+
+    def test_filter_by_denomination_case_insensitive(self, api_client, db):
+        RegioneFactory(denomination="Piemonte")
+        response = api_client.get(reverse("regioni-list"), {"denomination": "PIEM"})
+        assert response.data["count"] == 1
+
+    def test_filter_by_geographic_partition(self, api_client, db):
+        RegioneFactory(geographic_partition="Nord-Ovest")
+        RegioneFactory(geographic_partition="Sud")
+        response = api_client.get(reverse("regioni-list"), {"geographic_partition": "Nord"})
+        assert response.data["count"] == 1
+        assert response.data["results"][0]["geographic_partition"] == "Nord-Ovest"
+
+    def test_filter_no_match_returns_empty(self, api_client, db):
+        RegioneFactory(denomination="Piemonte")
+        response = api_client.get(reverse("regioni-list"), {"denomination": "Sardegna"})
+        assert response.data["count"] == 0

--- a/comuni_italiani/tests/regioni/test_regioni_models.py
+++ b/comuni_italiani/tests/regioni/test_regioni_models.py
@@ -1,8 +1,24 @@
 import pytest
-from tests.regioni.fixtures import regione  # noqa: F401
+from django.db import IntegrityError
+
+from comuni_italiani.tests.factories import RegioneFactory
 
 
-class TestRegioniModel:
-    @pytest.mark.django_db
-    def test_regioni_srt_ok(self, regione):
-        assert regione.__str__() == f"Regione: {regione.denomination}"  # noqa: F811
+@pytest.mark.django_db
+class TestRegioneModel:
+    def test_str(self, regione):
+        assert str(regione) == f"Regione: {regione.denomination}"
+
+    def test_code_is_unique(self, db):
+        RegioneFactory(code="01")
+        with pytest.raises(IntegrityError):
+            RegioneFactory(code="01")
+
+    def test_ordering_by_denomination(self, db):
+        RegioneFactory(denomination="Zeta")
+        RegioneFactory(denomination="Alpha")
+        RegioneFactory(denomination="Mela")
+        from comuni_italiani.models import Regione
+
+        denominations = list(Regione.objects.values_list("denomination", flat=True))
+        assert denominations == sorted(denominations)

--- a/comuni_italiani/tests/regioni/test_regioni_serializers.py
+++ b/comuni_italiani/tests/regioni/test_regioni_serializers.py
@@ -1,0 +1,45 @@
+import pytest
+
+from comuni_italiani.serializers import RegioneSerializer
+from comuni_italiani.tests.factories import ProvinciaFactory
+
+
+@pytest.mark.django_db
+class TestRegioneSerializer:
+    def test_contains_expected_fields(self, regione):
+        data = RegioneSerializer(regione).data
+        assert set(data.keys()) == {
+            "id",
+            "code",
+            "denomination",
+            "geographic_partition",
+            "provinces",
+            "provinces_count",
+        }
+
+    def test_dynamic_fields(self, regione):
+        data = RegioneSerializer(regione, fields=["id", "code"]).data
+        assert set(data.keys()) == {"id", "code"}
+
+    def test_provinces_count_zero(self, regione):
+        data = RegioneSerializer(regione).data
+        assert data["provinces_count"] == 0
+
+    def test_provinces_count_matches_related(self, regione):
+        ProvinciaFactory.create_batch(3, region=regione)
+        data = RegioneSerializer(regione).data
+        assert data["provinces_count"] == 3
+
+    def test_provinces_nested_fields(self, regione):
+        provincia = ProvinciaFactory(region=regione)
+        data = RegioneSerializer(regione).data
+        assert len(data["provinces"]) == 1
+        province_data = data["provinces"][0]
+        assert set(province_data.keys()) == {
+            "id",
+            "code",
+            "denomination",
+            "geographic_partition",
+            "auto_code",
+        }
+        assert province_data["id"] == provincia.pk

--- a/comuni_italiani/tests/settings.py
+++ b/comuni_italiani/tests/settings.py
@@ -6,13 +6,10 @@ SECRET_KEY = "django-admin-interface"
 
 ALLOWED_HOSTS = ["*"]
 
-# Application definition
 INSTALLED_APPS = [
     "comuni_italiani",
-]
-
-
-INSTALLED_APPS += [
+    "rest_framework",
+    "django_filters",
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
@@ -21,10 +18,10 @@ INSTALLED_APPS += [
 ]
 
 MIDDLEWARE = [
-    "django.contrib.auth.middleware.AuthenticationMiddleware",
-    "django.contrib.messages.middleware.MessageMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
 ]
 
 TEMPLATES = [
@@ -45,9 +42,24 @@ TEMPLATES = [
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",
-        "NAME": "db.sqlite3",
+        "NAME": ":memory:",
     }
 }
+
+ROOT_URLCONF = "comuni_italiani.tests.urls"
+
+REST_FRAMEWORK = {
+    "DEFAULT_FILTER_BACKENDS": [
+        "django_filters.rest_framework.DjangoFilterBackend",
+        "rest_framework.filters.SearchFilter",
+    ],
+    "DEFAULT_AUTHENTICATION_CLASSES": [],
+    "DEFAULT_PERMISSION_CLASSES": [],
+    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
+    "PAGE_SIZE": 20,
+}
+
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 USE_I18N = True
 LANGUAGE_CODE = "en"

--- a/comuni_italiani/tests/urls.py
+++ b/comuni_italiani/tests/urls.py
@@ -1,0 +1,5 @@
+from django.urls import include, path
+
+urlpatterns = [
+    path("", include("comuni_italiani.urls")),
+]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,7 @@
 [pytest]
-DJANGO_SETTINGS_MODULE = tests.settings
+DJANGO_SETTINGS_MODULE = comuni_italiani.tests.settings
+pythonpath = .
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+addopts = -v --tb=short

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+pytest
+pytest-django
+factory-boy


### PR DESCRIPTION
## Summary

- 84 test che coprono modelli, serializer, endpoint API e filtri per `Regione`, `Provincia` e `Comune`
- `factories.py` con `RegioneFactory`, `ProvinciaFactory`, `ComuneFactory` (factory-boy)
- `conftest.py` globale con fixture `api_client`, `regione`, `provincia`, `comune`
- Settings di test aggiornate: DRF, `django_filters`, paginazione, `ROOT_URLCONF`
- Workflow GitHub Actions (`.github/workflows/tests.yml`) su Python 3.10 / 3.11 / 3.12
- `requirements-dev.txt` con `pytest`, `pytest-django`, `factory-boy`

## Test plan

- [x] 84/84 test passano in locale (`pytest comuni_italiani/tests/`)
- [x] Pre-commit hooks (ruff, trailing-whitespace, end-of-file) superati
- [x] Verificare che il workflow CI passi su GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)